### PR TITLE
small fix

### DIFF
--- a/imgui_impl_raylib.cpp
+++ b/imgui_impl_raylib.cpp
@@ -275,7 +275,7 @@ void ImGui_ImplRaylib_LoadDefaultFontAtlas()
         image.width = width;
         image.height = height;
         image.mipmaps = 1;
-        image.format = UNCOMPRESSED_R8G8B8A8;
+        image.format = PIXELFORMAT_UNCOMPRESSED_R8G8B8A8;
         Texture2D tex = LoadTextureFromImage(image);
 		g_AtlasTexID = tex.id;
 		io.Fonts->TexID = (void*)&g_AtlasTexID;

--- a/imgui_impl_raylib.cpp
+++ b/imgui_impl_raylib.cpp
@@ -38,7 +38,7 @@ bool ImGui_ImplRaylib_Init()
     io.KeyMap[ImGuiKey_Space] = KEY_SPACE;
     io.KeyMap[ImGuiKey_Enter] = KEY_ENTER;
     io.KeyMap[ImGuiKey_Escape] = KEY_ESCAPE;
-    io.KeyMap[ImGuiKey_KeyPadEnter] = KEY_KP_ENTER;
+    io.KeyMap[ImGuiKey_KeypadEnter] = KEY_KP_ENTER;
     io.KeyMap[ImGuiKey_A] = KEY_A;
     io.KeyMap[ImGuiKey_C] = KEY_C;
     io.KeyMap[ImGuiKey_V] = KEY_V;
@@ -249,7 +249,7 @@ bool ImGui_ImplRaylib_ProcessEvent()
     //{
 #ifdef ENABLE_SCODETOUTF8
     int length;     //  Length was only ever created to be passed to CodepointToUtf8(), since it doesn't check for nullptrs.
-    io.AddInputCharactersUTF8(CodepointToUtf8(GetCharPressed(), &length));
+    io.AddInputCharactersUTF8(CodepointToUTF8(GetCharPressed(), &length));
     (void)length;   //  Silencing the compiler warnings.
 #else
     io.AddInputCharacter(GetKeyPressed());


### PR DESCRIPTION
Two expressions in imgui changed by 1 or 2 letters. This means it will not compile with newer versions of imgui (v1.90.4).